### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
   </a>
 </p>
 
+[![Run on Repl.it](https://repl.it/badge/github/bryanchappell/dashboard)](https://repl.it/github/bryanchappell/dashboard)
+
 ## Table of Contents
 
 * [Installation](#installation)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).